### PR TITLE
elastic monitor: added runNumber field (for elasticsearch 5) and additional error logging

### DIFF
--- a/cmsActualMergingFiles.py
+++ b/cmsActualMergingFiles.py
@@ -33,6 +33,7 @@ def elasticMonitor(mergeMonitorData, runnumber, mergeType, esServerUrl, esIndexN
    #mergeMonitorDict['fm_date']=float(mergeMonitorDict['fm_date'])
    documentId = mergeMonitorData[-1]
    mergeMonitorDict["host"]=host
+   mergeMonitorDict["runNumber"]=int(runnumber)
    while True:
       try:
   #requests.post(esServerUrl+'/_bulk','{"_type": "macromerge", "_index": "'+esIndexName+'"}}\n'+json.dumps(mergeMonitorDict)+'\n')

--- a/cmsActualMergingFiles.py
+++ b/cmsActualMergingFiles.py
@@ -30,13 +30,11 @@ def elasticMonitor(mergeMonitorData, runnumber, mergeType, esServerUrl, esIndexN
    keys = ["processed","accepted","errorEvents","fname","size","eolField1","eolField2","fm_date","ls","stream"]
    values = [int(f) if str(f).isdigit() else str(f) for f in mergeMonitorData]
    mergeMonitorDict=dict(zip(keys,values))
-   #mergeMonitorDict['fm_date']=float(mergeMonitorDict['fm_date'])
    documentId = mergeMonitorData[-1]
    mergeMonitorDict["host"]=host
    mergeMonitorDict["runNumber"]=int(runnumber)
    while True:
       try:
-  #requests.post(esServerUrl+'/_bulk','{"_type": "macromerge", "_index": "'+esIndexName+'"}}\n'+json.dumps(mergeMonitorDict)+'\n')
          documentType=mergeType+'merge'
          if(float(debug) >= 10):
             log.info("About to try to insert into ES with the following info:")
@@ -45,6 +43,8 @@ def elasticMonitor(mergeMonitorData, runnumber, mergeType, esServerUrl, esIndexN
          #attempt to record the merge, 1s timeout!
          monitorResponse=requests.post(esServerUrl+'/'+esIndexName+'/'+documentType+'/'+documentId,data=json.dumps(mergeMonitorDict),timeout=1)
          if(float(debug) >= 10): log.info("Merger monitor produced response: {0}".format(monitorResponse.text))
+         if monitorResponse.status_code!=200:
+             log.error("elasticsearch replied with error code {0} and response: {1}".format(monitorResponse.status_code,monitorResponse.text))
          break
       except (requests.exceptions.ConnectionError,requests.exceptions.Timeout) as e:
          log.error('elasticMonitor threw connection error: HTTP ' + monitorResponse.status_code)

--- a/cmsDataFlowMerger.py
+++ b/cmsDataFlowMerger.py
@@ -51,7 +51,6 @@ def esMonitorMapping(esServerUrl,esIndexName,numberOfShards,numberOfReplicas,deb
       minimerge_mapping = {
          'minimerge' : {
 	    '_all'       : {'enabled' : 'false'},
-            '_timestamp' : {'enabled' : 'true'},
             'properties' : {
                'fm_date'       :{'type':'date'},
                'id'            :{'type':'string','index' : 'not_analyzed'}, #run+appliance+stream+ls
@@ -66,14 +65,14 @@ def esMonitorMapping(esServerUrl,esIndexName,numberOfShards,numberOfReplicas,deb
                'size'          :{'type':'long'},
                'eolField1'     :{'type':'integer'},
                'eolField2'     :{'type':'integer'},
-               'adler32'       :{'type':'long'}
+               'adler32'       :{'type':'long'},
+               'runNumber'     :{'type':'integer'}
             }
          }
       }
       macromerge_mapping = {
          'macromerge' : {
 	    '_all'       : {'enabled' : 'false'},
-            '_timestamp' : {'enabled' : 'true'},
             'properties' : {
                'fm_date'       :{'type':'date'},
                'id'            :{'type':'string','index' : 'not_analyzed'}, #run+appliance+stream+ls
@@ -87,7 +86,8 @@ def esMonitorMapping(esServerUrl,esIndexName,numberOfShards,numberOfReplicas,deb
                'errorEvents'   :{'type':'integer'},
                'size'          :{'type':'long'},
                'eolField1'     :{'type':'integer'},
-               'eolField2'     :{'type':'integer'}
+               'eolField2'     :{'type':'integer'},
+               'runNumber'     :{'type':'integer'}
             }
          }
       }
@@ -116,7 +116,9 @@ def esMonitorMapping(esServerUrl,esIndexName,numberOfShards,numberOfReplicas,deb
          },
          "index":{
             'number_of_shards' : numberOfShards,
-            'number_of_replicas' : numberOfReplicas
+            'number_of_replicas' : numberOfReplicas,
+            'translog':{'durability':'async'},
+            'mapper':{'dynamic':'false'}
          },
       }
 
@@ -138,7 +140,8 @@ def esMonitorMapping(esServerUrl,esIndexName,numberOfShards,numberOfReplicas,deb
                'size'          :{'type':'long'},
                'eolField1'     :{'type':'integer'},
                'eolField2'     :{'type':'integer'},
-               'adler32'       :{'type':'long'}
+               'adler32'       :{'type':'long'},
+               'runNumber'     :{'type':'integer'}
             }
          },
          'macromerge' : {
@@ -158,6 +161,7 @@ def esMonitorMapping(esServerUrl,esIndexName,numberOfShards,numberOfReplicas,deb
                'size'          :{'type':'long'},
                'eolField1'     :{'type':'integer'},
                'eolField2'     :{'type':'integer'},
+               'runNumber'     :{'type':'integer'}
             }
          }
       }


### PR DESCRIPTION
Elasticsearch 5 no longer allows certain queries on "_id" field such as:
{"prefix":
  "_id": "run270280_ls0012_streamN"
}
which has been used in f3mon to select mini and macromerge documents from a certain run.
All information from id is already indexed separately except the run number, which has to be added for F3mon to continue working after upgrade to elastic 5.

First set of changes adds run number and also included are mapping and settings updates for elasticsearch 5.

Second change is error logging when elasticsearch returns HTTP error, which is not thrown as exception with requests library, so it has to be detected by checking returned status_code.